### PR TITLE
Feat: Introducing Async DB as plug and play

### DIFF
--- a/creyPY/fastapi/db/__init__.py
+++ b/creyPY/fastapi/db/__init__.py
@@ -1,1 +1,2 @@
 from .session import *  # noqa
+from .async_session import * #noqa

--- a/creyPY/fastapi/db/async_session.py
+++ b/creyPY/fastapi/db/async_session.py
@@ -1,0 +1,25 @@
+import os
+from typing import AsyncGenerator
+from dotenv import load_dotenv
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+
+load_dotenv()
+
+host = os.getenv("POSTGRES_HOST", "localhost")
+user = os.getenv("POSTGRES_USER", "postgres")
+password = os.getenv("POSTGRES_PASSWORD", "root")
+port = os.getenv("POSTGRES_PORT", "5432")
+name = os.getenv("POSTGRES_DB", "fastapi")
+
+SQLALCHEMY_DATABASE_URL = f"postgresql+psycopg://{user}:{password}@{host}:{port}/"
+
+
+async_engine = create_async_engine(SQLALCHEMY_DATABASE_URL + name, pool_pre_ping=True)
+AsyncSessionLocal = sessionmaker(bind=async_engine, class_=AsyncSession,
+                                expire_on_commit=False, autoflush=False, autocommit=False)
+
+async def get_async_db() -> AsyncGenerator[AsyncSession, None]:
+    async with AsyncSessionLocal() as db:
+        yield db

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,5 @@ psycopg-pool>=3.2.2 # PostgreSQL
 h11>=0.14.0 # Testing
 httpcore>=1.0.5 # Testing
 httpx>=0.27.0 # Testing
+asyncpg>=0.30.0
+greenlet>=3.1.1


### PR DESCRIPTION
I have modified the Paginate function to accommodate both sync and async DB. However, as a result, we should use await options in places where we use the paginate function. Is this fine or should I create separate paginate functions for both cases ?